### PR TITLE
Add join listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # python-join
 Python API for Join by Joao
+
+
+### To use the listener:
+
+``` python 
+import pyjoin
+
+def callback(data):
+    print(data)
+
+api_key = "<JOIN_API_KEY>"
+l = pyjoin.Listener(name="server-test",port=5050, api_key=api_key)
+l.add_callback(callback)
+l.run()
+
+```
+
+#### Output:
+
+``` python
+{u'json': u'{"push":{"location":false,"fromTasker":false,"toTasker":false,"find":false,"id":"89a694e8-d71b-440e-ad26-0a7034c4b972","deviceId":"0d2aa1c3c16b4e9e9251c2301f37641c","text":"hello"}}', u'type': u'GCMPush'}
+```

--- a/pyjoin/__init__.py
+++ b/pyjoin/__init__.py
@@ -1,9 +1,77 @@
 """Python API for using Join by joaoapps."""
 import requests
+from flask import request, Response, Flask
+import os 
 
 SEND_URL = "https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush?apikey="
 LIST_URL = "https://joinjoaomgcd.appspot.com/_ah/api/registration/v1/listDevices?apikey="
+REGISTER_URL = "https://joinjoaomgcd.appspot.com/_ah/api/registration/v1/registerDevice/"
+PUBLIC_IP_URL = "https://api.ipify.org"
+DEFAULT_PORT = "1820"
 
+
+class Action(object):
+
+        def __init__(self, action):
+            self.action = action
+            self.response = Response(status=200, headers={"Content-Type": "text/html"})
+
+        def __call__(self, *args):
+            data = request.json
+            if self.action:
+                self.action(data)
+            return self.response
+
+class Listener:
+    def __init__(self, name, port, api_key,public_ip=None):
+        self.api_key = api_key
+        self.name = name
+        self.port = port 
+        if public_ip == None:
+            self.public_ip = self.get_public_ip()
+        else:
+            self.public_ip = public_ip
+
+        if port == None:
+            self.port = DEFAULT_PORT
+        else:
+            self.port = port
+
+        self.deviceID = self.get_device_id()
+        self.app = Flask(self.name)
+
+    def get_device_id(self):
+        devices = get_devices(self.api_key)
+        for d in devices:
+            name, id = d
+            if name == self.name:
+                return id
+        return self.register() 
+
+    def run(self):
+        self.app.run(host="0.0.0.0", port=self.port, debug=False, use_reloader=False)
+
+    def add_endpoint(self, endpoint=None, endpoint_name=None, handler=None):
+        self.app.add_url_rule(endpoint, endpoint_name, Action(handler),methods=["GET","POST"])
+
+    def register(self):
+        data = {
+            "apikey": self.api_key,
+            "regId": "{}:{}".format(self.public_ip,self.port),
+            "deviceName": self.name, 
+            "deviceType": 13
+        }
+        r = requests.post(REGISTER_URL, data = data)
+        if r.status_code!=200:
+            raise Exception("Unable to register to join")
+        return r.json().get("deviceId")
+
+    def get_public_ip(self):
+        r = requests.get(PUBLIC_IP_URL)
+        if r.status_code !=200:
+            raise Exception("Unable to get public IP")
+        return r.text
+    
 def get_devices(api_key):
     response = requests.get(LIST_URL + api_key).json()
     if response.get('success') and not response.get('userAuthError'):

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(name='python-join-api',
       author='Nolan Gilley',
       author_email='nkgilley@gmail.com',
       license='MIT',
-      install_requires=['requests>=2.0'],
+      install_requires=['requests>=2.0','flask>=1.1.2'],
       packages=['pyjoin'],
       zip_safe=True)


### PR DESCRIPTION
@nkgilley 
This adds a Listener class which can be used by other methods like this:
``` python
import pyjoin

def callback(data):
    print(data)

api_key = "<JOIN_API_KEY>"
l = pyjoin.Listener(name="server-test", port=5050, api_key=api_key)
l.add_callback(callback)
l.run()
```
When you send a join message from either tasker or any other device, the callback function gets called and the output looks like this:

``` python
{u'json': u'{"push":{"location":false,"fromTasker":false,"toTasker":false,"find":false,"id":"350ceca4-a343-4cd5-a0bc-477ff1888bc9","deviceId":"0d2aa1c3c16b4e9e9251c2301f37641c","text":"hello"}}', u'type': u'GCMPush'}
```