### PR TITLE
Added set_mediavolume() for Join API

### DIFF
--- a/pyjoin/__init__.py
+++ b/pyjoin/__init__.py
@@ -148,3 +148,10 @@ def send_sms(api_key, sms_number, sms_text, device_id=None, device_ids=None, dev
     if device_names: req_url += "&deviceNames=" + device_names
     requests.get(req_url)
 
+def set_mediavolume(api_key, mediavolume, device_id=None, device_ids=None, device_names=None):
+    if device_id is None and device_ids is None and device_names is None: return False
+    req_url = SEND_URL + api_key + "&mediaVolume=" + mediavolume
+    if device_id: req_url += "&deviceId=" + device_id
+    if device_ids: req_url += "&deviceIds=" + device_ids
+    if device_names: req_url += "&deviceNames=" + device_names
+    requests.get(req_url)


### PR DESCRIPTION
Added a set_mediavolume() call to be able to set the media playback volume of a device.  

Use case: Volume on my GSM is normally 0, so I want to be able to set it to 5 or 10, then send a TTS notification and eventually set it back to 0.
