### PR TITLE
Update __init__.py

### DIFF
--- a/pyjoin/__init__.py
+++ b/pyjoin/__init__.py
@@ -89,7 +89,7 @@ def get_devices(api_key):
           s = file.read()
         o = json.loads(s)
         return o
-    return Fals
+    return False
 
 def send_notification(api_key, text, device_id=None, device_ids=None, device_names=None, title=None, icon=None, smallicon=None, vibration=None, image=None, url=None, tts=None, tts_language=None, sound=None, notification_id=None, category=None, actions=None):
     if device_id is None and device_ids is None and device_names is None: return False

--- a/pyjoin/__init__.py
+++ b/pyjoin/__init__.py
@@ -74,9 +74,22 @@ class Listener:
     
 def get_devices(api_key):
     response = requests.get(LIST_URL + api_key).json()
+
+    mypath = os.path.dirname(__file__)
+
     if response.get('success') and not response.get('userAuthError'):
+        js = json.dumps([(r['deviceName'], r['deviceId']) for r in response['records']])
+        with open(mypath+'/'+api_key+'.json', 'w')  as fh:
+          fh.write(js)
         return [(r['deviceName'], r['deviceId']) for r in response['records']]
-    return False
+    else:
+
+      if os.path.isfile(mypath+'/'+api_key+'.json'):
+        with open(mypath+'/'+api_key+'.json', 'r') as file:
+          s = file.read()
+        o = json.loads(s)
+        return o
+    return Fals
 
 def send_notification(api_key, text, device_id=None, device_ids=None, device_names=None, title=None, icon=None, smallicon=None, vibration=None, image=None, url=None, tts=None, tts_language=None, sound=None, notification_id=None, category=None, actions=None):
     if device_id is None and device_ids is None and device_names is None: return False

--- a/pyjoin/__init__.py
+++ b/pyjoin/__init__.py
@@ -1,7 +1,8 @@
 """Python API for using Join by joaoapps."""
 import requests
 from flask import request, Response, Flask
-import os 
+import os
+import json
 
 SEND_URL = "https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush?apikey="
 LIST_URL = "https://joinjoaomgcd.appspot.com/_ah/api/registration/v1/listDevices?apikey="


### PR DESCRIPTION
Home assistant uses this package and calls the get_devices function one or more times, depending on how many devices are defined in the home assistant configuration. If at the moment of initialization there is no internet or the joaoapps server temporarily blocks calls, the join integration is not initialized and the only way to initialize it again is to restart the home assistant. I made a change so that the response for each api_key is saved locally and in case the internet is not available, the function returns the saved data instead of False. In this way, it is possible to restart the home assistant even in moments when the internet is not available without being left without join integration.

Please merge this pull request.
Best regards
Igor Simić